### PR TITLE
Update libnice and use port ranges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "LGPL-2.1 OR MPL-1.1"
 repository = "https://github.com/johni0702/rust-libnice"
 
 [dependencies]
-libnice-sys = "0.1"
+libnice-sys = { git = "https://github.com/abbradar/rust-libnice-sys", rev = "78b0b60" }
 foreign-types = "0.3"
 futures = "0.1"
 # webrtc-sdp = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,10 @@ license = "LGPL-2.1 OR MPL-1.1"
 repository = "https://github.com/johni0702/rust-libnice"
 
 [dependencies]
-libnice-sys = { git = "https://github.com/abbradar/rust-libnice-sys", rev = "78b0b60" }
+libnice-sys = { git = "https://github.com/abbradar/rust-libnice-sys", rev = "3a56dda" }
+libc = "0.2.62"
+glib-sys = "0.7"
+gobject-sys = "0.7"
 foreign-types = "0.3"
 futures = "0.1"
 # webrtc-sdp = "0.2"


### PR DESCRIPTION
This moves the library to libnice version 0.2.0 (from my fork now because I need a bindgen update) and also adds calls for specifying port ranges.