### PR TITLE
Cargo.toml: bump glib version requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ repository = "https://github.com/johni0702/rust-libnice"
 [dependencies]
 libnice-sys = "0.3"
 libc = "0.2"
-glib-sys = "0.9"
-gobject-sys = "0.9"
-glib = "0.9"
+glib-sys = "0.10"
+gobject-sys = "0.10"
+glib = "0.10"
 futures = "0.3"
 webrtc-sdp = "0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "LGPL-2.1 OR MPL-1.1"
 repository = "https://github.com/johni0702/rust-libnice"
 
 [dependencies]
-libnice-sys = "0.3"
+libnice-sys = "0.4"
 libc = "0.2"
 glib-sys = "0.10"
 gobject-sys = "0.10"


### PR DESCRIPTION
This crate builds with 0.10